### PR TITLE
delete 3 lines in _navbar

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -16,9 +16,7 @@
             <% else %>
               <% user = current_teacher %>
             <% end %>
-            <a href="#" class="avatar" id="navbarDropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              <%= image_tag user.avatar_url, class: "avatar", alt: "dropdown menu" %>
-            </a>
+
             <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
               <%= link_to "Action", "#", class: "dropdown-item" %>
               <%= link_to "Another action", "#", class: "dropdown-item" %>


### PR DESCRIPTION
Tested login for teacher and student. Able to login. 
However, couldn't get to other pages due to _navbar.html.erb contains code of user.avatar_url which we don't have devise user. We have devise student and teacher instead. Deleted that part. Now able to access other pages as students but no logout button show. 